### PR TITLE
Fixed bug causing wrong URLs when basepath contains a slash

### DIFF
--- a/NgrokApi/Services/AbuseReports.cs
+++ b/NgrokApi/Services/AbuseReports.cs
@@ -34,7 +34,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<AbuseReport>(
-                  path: $"/abuse_reports",
+                  path: $"abuse_reports",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query
@@ -57,7 +57,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<AbuseReport>(
-                  path: $"/abuse_reports/{arg.Id}",
+                  path: $"abuse_reports/{arg.Id}",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/AgentIngresses.cs
+++ b/NgrokApi/Services/AgentIngresses.cs
@@ -28,7 +28,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<AgentIngress>(
-                  path: $"/agent_ingresses",
+                  path: $"agent_ingresses",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query
@@ -51,7 +51,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/agent_ingresses/{arg.Id}",
+                  path: $"agent_ingresses/{arg.Id}",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query
@@ -73,7 +73,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<AgentIngress>(
-                  path: $"/agent_ingresses/{arg.Id}",
+                  path: $"agent_ingresses/{arg.Id}",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -92,7 +92,7 @@ namespace NgrokApi
                 ["limit"] = arg.Limit,
             };
             return await apiClient.Do<AgentIngressList>(
-                  path: $"/agent_ingresses",
+                  path: $"agent_ingresses",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -129,7 +129,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<AgentIngress>(
-                  path: $"/agent_ingresses/{arg.Id}",
+                  path: $"agent_ingresses/{arg.Id}",
                   method: new HttpMethod("patch"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/ApiKeys.cs
+++ b/NgrokApi/Services/ApiKeys.cs
@@ -38,7 +38,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<ApiKey>(
-                  path: $"/api_keys",
+                  path: $"api_keys",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query
@@ -61,7 +61,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/api_keys/{arg.Id}",
+                  path: $"api_keys/{arg.Id}",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query
@@ -83,7 +83,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<ApiKey>(
-                  path: $"/api_keys/{arg.Id}",
+                  path: $"api_keys/{arg.Id}",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -102,7 +102,7 @@ namespace NgrokApi
                 ["limit"] = arg.Limit,
             };
             return await apiClient.Do<ApiKeyList>(
-                  path: $"/api_keys",
+                  path: $"api_keys",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -139,7 +139,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<ApiKey>(
-                  path: $"/api_keys/{arg.Id}",
+                  path: $"api_keys/{arg.Id}",
                   method: new HttpMethod("patch"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/CertificateAuthorities.cs
+++ b/NgrokApi/Services/CertificateAuthorities.cs
@@ -35,7 +35,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<CertificateAuthority>(
-                  path: $"/certificate_authorities",
+                  path: $"certificate_authorities",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query
@@ -58,7 +58,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/certificate_authorities/{arg.Id}",
+                  path: $"certificate_authorities/{arg.Id}",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query
@@ -80,7 +80,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<CertificateAuthority>(
-                  path: $"/certificate_authorities/{arg.Id}",
+                  path: $"certificate_authorities/{arg.Id}",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -99,7 +99,7 @@ namespace NgrokApi
                 ["limit"] = arg.Limit,
             };
             return await apiClient.Do<CertificateAuthorityList>(
-                  path: $"/certificate_authorities",
+                  path: $"certificate_authorities",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -136,7 +136,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<CertificateAuthority>(
-                  path: $"/certificate_authorities/{arg.Id}",
+                  path: $"certificate_authorities/{arg.Id}",
                   method: new HttpMethod("patch"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/Credentials.cs
+++ b/NgrokApi/Services/Credentials.cs
@@ -37,7 +37,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<Credential>(
-                  path: $"/credentials",
+                  path: $"credentials",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query
@@ -60,7 +60,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/credentials/{arg.Id}",
+                  path: $"credentials/{arg.Id}",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query
@@ -82,7 +82,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<Credential>(
-                  path: $"/credentials/{arg.Id}",
+                  path: $"credentials/{arg.Id}",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -101,7 +101,7 @@ namespace NgrokApi
                 ["limit"] = arg.Limit,
             };
             return await apiClient.Do<CredentialList>(
-                  path: $"/credentials",
+                  path: $"credentials",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -138,7 +138,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<Credential>(
-                  path: $"/credentials/{arg.Id}",
+                  path: $"credentials/{arg.Id}",
                   method: new HttpMethod("patch"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/EndpointCircuitBreakerModule.cs
+++ b/NgrokApi/Services/EndpointCircuitBreakerModule.cs
@@ -22,7 +22,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<EndpointCircuitBreaker>(
-                  path: $"/endpoint_configurations/{arg.Id}/circuit_breaker",
+                  path: $"endpoint_configurations/{arg.Id}/circuit_breaker",
                   method: new HttpMethod("put"),
                   body: body,
                   query: query
@@ -40,7 +40,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<EndpointCircuitBreaker>(
-                  path: $"/endpoint_configurations/{arg.Id}/circuit_breaker",
+                  path: $"endpoint_configurations/{arg.Id}/circuit_breaker",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -58,7 +58,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/endpoint_configurations/{arg.Id}/circuit_breaker",
+                  path: $"endpoint_configurations/{arg.Id}/circuit_breaker",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/EndpointCompressionModule.cs
+++ b/NgrokApi/Services/EndpointCompressionModule.cs
@@ -22,7 +22,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<EndpointCompression>(
-                  path: $"/endpoint_configurations/{arg.Id}/compression",
+                  path: $"endpoint_configurations/{arg.Id}/compression",
                   method: new HttpMethod("put"),
                   body: body,
                   query: query
@@ -40,7 +40,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<EndpointCompression>(
-                  path: $"/endpoint_configurations/{arg.Id}/compression",
+                  path: $"endpoint_configurations/{arg.Id}/compression",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -58,7 +58,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/endpoint_configurations/{arg.Id}/compression",
+                  path: $"endpoint_configurations/{arg.Id}/compression",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/EndpointConfigurations.cs
+++ b/NgrokApi/Services/EndpointConfigurations.cs
@@ -33,7 +33,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<EndpointConfiguration>(
-                  path: $"/endpoint_configurations",
+                  path: $"endpoint_configurations",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query
@@ -57,7 +57,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/endpoint_configurations/{arg.Id}",
+                  path: $"endpoint_configurations/{arg.Id}",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query
@@ -79,7 +79,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<EndpointConfiguration>(
-                  path: $"/endpoint_configurations/{arg.Id}",
+                  path: $"endpoint_configurations/{arg.Id}",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -98,7 +98,7 @@ namespace NgrokApi
                 ["limit"] = arg.Limit,
             };
             return await apiClient.Do<EndpointConfigurationList>(
-                  path: $"/endpoint_configurations",
+                  path: $"endpoint_configurations",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -138,7 +138,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<EndpointConfiguration>(
-                  path: $"/endpoint_configurations/{arg.Id}",
+                  path: $"endpoint_configurations/{arg.Id}",
                   method: new HttpMethod("patch"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/EndpointIpPolicyModule.cs
+++ b/NgrokApi/Services/EndpointIpPolicyModule.cs
@@ -22,7 +22,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<EndpointIpPolicy>(
-                  path: $"/endpoint_configurations/{arg.Id}/ip_policy",
+                  path: $"endpoint_configurations/{arg.Id}/ip_policy",
                   method: new HttpMethod("put"),
                   body: body,
                   query: query
@@ -40,7 +40,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<EndpointIpPolicy>(
-                  path: $"/endpoint_configurations/{arg.Id}/ip_policy",
+                  path: $"endpoint_configurations/{arg.Id}/ip_policy",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -58,7 +58,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/endpoint_configurations/{arg.Id}/ip_policy",
+                  path: $"endpoint_configurations/{arg.Id}/ip_policy",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/EndpointLoggingModule.cs
+++ b/NgrokApi/Services/EndpointLoggingModule.cs
@@ -22,7 +22,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<EndpointLogging>(
-                  path: $"/endpoint_configurations/{arg.Id}/logging",
+                  path: $"endpoint_configurations/{arg.Id}/logging",
                   method: new HttpMethod("put"),
                   body: body,
                   query: query
@@ -40,7 +40,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<EndpointLogging>(
-                  path: $"/endpoint_configurations/{arg.Id}/logging",
+                  path: $"endpoint_configurations/{arg.Id}/logging",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -58,7 +58,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/endpoint_configurations/{arg.Id}/logging",
+                  path: $"endpoint_configurations/{arg.Id}/logging",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/EndpointMutualTlsModule.cs
+++ b/NgrokApi/Services/EndpointMutualTlsModule.cs
@@ -22,7 +22,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<EndpointMutualTls>(
-                  path: $"/endpoint_configurations/{arg.Id}/mutual_tls",
+                  path: $"endpoint_configurations/{arg.Id}/mutual_tls",
                   method: new HttpMethod("put"),
                   body: body,
                   query: query
@@ -40,7 +40,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<EndpointMutualTls>(
-                  path: $"/endpoint_configurations/{arg.Id}/mutual_tls",
+                  path: $"endpoint_configurations/{arg.Id}/mutual_tls",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -58,7 +58,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/endpoint_configurations/{arg.Id}/mutual_tls",
+                  path: $"endpoint_configurations/{arg.Id}/mutual_tls",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/EndpointOAuthModule.cs
+++ b/NgrokApi/Services/EndpointOAuthModule.cs
@@ -22,7 +22,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<EndpointOAuth>(
-                  path: $"/endpoint_configurations/{arg.Id}/oauth",
+                  path: $"endpoint_configurations/{arg.Id}/oauth",
                   method: new HttpMethod("put"),
                   body: body,
                   query: query
@@ -40,7 +40,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<EndpointOAuth>(
-                  path: $"/endpoint_configurations/{arg.Id}/oauth",
+                  path: $"endpoint_configurations/{arg.Id}/oauth",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -58,7 +58,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/endpoint_configurations/{arg.Id}/oauth",
+                  path: $"endpoint_configurations/{arg.Id}/oauth",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/EndpointOidcModule.cs
+++ b/NgrokApi/Services/EndpointOidcModule.cs
@@ -22,7 +22,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<EndpointOidc>(
-                  path: $"/endpoint_configurations/{arg.Id}/oidc",
+                  path: $"endpoint_configurations/{arg.Id}/oidc",
                   method: new HttpMethod("put"),
                   body: body,
                   query: query
@@ -40,7 +40,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<EndpointOidc>(
-                  path: $"/endpoint_configurations/{arg.Id}/oidc",
+                  path: $"endpoint_configurations/{arg.Id}/oidc",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -58,7 +58,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/endpoint_configurations/{arg.Id}/oidc",
+                  path: $"endpoint_configurations/{arg.Id}/oidc",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/EndpointRequestHeadersModule.cs
+++ b/NgrokApi/Services/EndpointRequestHeadersModule.cs
@@ -22,7 +22,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<EndpointRequestHeaders>(
-                  path: $"/endpoint_configurations/{arg.Id}/request_headers",
+                  path: $"endpoint_configurations/{arg.Id}/request_headers",
                   method: new HttpMethod("put"),
                   body: body,
                   query: query
@@ -40,7 +40,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<EndpointRequestHeaders>(
-                  path: $"/endpoint_configurations/{arg.Id}/request_headers",
+                  path: $"endpoint_configurations/{arg.Id}/request_headers",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -58,7 +58,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/endpoint_configurations/{arg.Id}/request_headers",
+                  path: $"endpoint_configurations/{arg.Id}/request_headers",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/EndpointResponseHeadersModule.cs
+++ b/NgrokApi/Services/EndpointResponseHeadersModule.cs
@@ -22,7 +22,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<EndpointResponseHeaders>(
-                  path: $"/endpoint_configurations/{arg.Id}/response_headers",
+                  path: $"endpoint_configurations/{arg.Id}/response_headers",
                   method: new HttpMethod("put"),
                   body: body,
                   query: query
@@ -40,7 +40,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<EndpointResponseHeaders>(
-                  path: $"/endpoint_configurations/{arg.Id}/response_headers",
+                  path: $"endpoint_configurations/{arg.Id}/response_headers",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -58,7 +58,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/endpoint_configurations/{arg.Id}/response_headers",
+                  path: $"endpoint_configurations/{arg.Id}/response_headers",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/EndpointSamlModule.cs
+++ b/NgrokApi/Services/EndpointSamlModule.cs
@@ -22,7 +22,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<EndpointSaml>(
-                  path: $"/endpoint_configurations/{arg.Id}/saml",
+                  path: $"endpoint_configurations/{arg.Id}/saml",
                   method: new HttpMethod("put"),
                   body: body,
                   query: query
@@ -40,7 +40,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<EndpointSaml>(
-                  path: $"/endpoint_configurations/{arg.Id}/saml",
+                  path: $"endpoint_configurations/{arg.Id}/saml",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -58,7 +58,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/endpoint_configurations/{arg.Id}/saml",
+                  path: $"endpoint_configurations/{arg.Id}/saml",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/EndpointTlsTerminationModule.cs
+++ b/NgrokApi/Services/EndpointTlsTerminationModule.cs
@@ -22,7 +22,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<EndpointTlsTermination>(
-                  path: $"/endpoint_configurations/{arg.Id}/tls_termination",
+                  path: $"endpoint_configurations/{arg.Id}/tls_termination",
                   method: new HttpMethod("put"),
                   body: body,
                   query: query
@@ -40,7 +40,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<EndpointTlsTermination>(
-                  path: $"/endpoint_configurations/{arg.Id}/tls_termination",
+                  path: $"endpoint_configurations/{arg.Id}/tls_termination",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -58,7 +58,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/endpoint_configurations/{arg.Id}/tls_termination",
+                  path: $"endpoint_configurations/{arg.Id}/tls_termination",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/EndpointWebhookValidationModule.cs
+++ b/NgrokApi/Services/EndpointWebhookValidationModule.cs
@@ -22,7 +22,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<EndpointWebhookValidation>(
-                  path: $"/endpoint_configurations/{arg.Id}/webhook_validation",
+                  path: $"endpoint_configurations/{arg.Id}/webhook_validation",
                   method: new HttpMethod("put"),
                   body: body,
                   query: query
@@ -40,7 +40,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<EndpointWebhookValidation>(
-                  path: $"/endpoint_configurations/{arg.Id}/webhook_validation",
+                  path: $"endpoint_configurations/{arg.Id}/webhook_validation",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -58,7 +58,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/endpoint_configurations/{arg.Id}/webhook_validation",
+                  path: $"endpoint_configurations/{arg.Id}/webhook_validation",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/EventDestinations.cs
+++ b/NgrokApi/Services/EventDestinations.cs
@@ -29,7 +29,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<EventDestination>(
-                  path: $"/event_destinations",
+                  path: $"event_destinations",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query
@@ -54,7 +54,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/event_destinations/{arg.Id}",
+                  path: $"event_destinations/{arg.Id}",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query
@@ -76,7 +76,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<EventDestination>(
-                  path: $"/event_destinations/{arg.Id}",
+                  path: $"event_destinations/{arg.Id}",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -95,7 +95,7 @@ namespace NgrokApi
                 ["limit"] = arg.Limit,
             };
             return await apiClient.Do<EventDestinationList>(
-                  path: $"/event_destinations",
+                  path: $"event_destinations",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -132,7 +132,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<EventDestination>(
-                  path: $"/event_destinations/{arg.Id}",
+                  path: $"event_destinations/{arg.Id}",
                   method: new HttpMethod("patch"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/EventSources.cs
+++ b/NgrokApi/Services/EventSources.cs
@@ -27,7 +27,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<EventSource>(
-                  path: $"/event_subscriptions/{arg.SubscriptionId}/sources",
+                  path: $"event_subscriptions/{arg.SubscriptionId}/sources",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query
@@ -48,7 +48,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/event_subscriptions/{arg.SubscriptionId}/sources/{arg.Type}",
+                  path: $"event_subscriptions/{arg.SubscriptionId}/sources/{arg.Type}",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query
@@ -68,7 +68,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<EventSource>(
-                  path: $"/event_subscriptions/{arg.SubscriptionId}/sources/{arg.Type}",
+                  path: $"event_subscriptions/{arg.SubscriptionId}/sources/{arg.Type}",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -91,7 +91,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<EventSourceList>(
-                  path: $"/event_subscriptions/{arg.SubscriptionId}/sources",
+                  path: $"event_subscriptions/{arg.SubscriptionId}/sources",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -111,7 +111,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<EventSource>(
-                  path: $"/event_subscriptions/{arg.SubscriptionId}/sources/{arg.Type}",
+                  path: $"event_subscriptions/{arg.SubscriptionId}/sources/{arg.Type}",
                   method: new HttpMethod("patch"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/EventStreams.cs
+++ b/NgrokApi/Services/EventStreams.cs
@@ -28,7 +28,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<EventStream>(
-                  path: $"/event_streams",
+                  path: $"event_streams",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query
@@ -51,7 +51,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/event_streams/{arg.Id}",
+                  path: $"event_streams/{arg.Id}",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query
@@ -73,7 +73,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<EventStream>(
-                  path: $"/event_streams/{arg.Id}",
+                  path: $"event_streams/{arg.Id}",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -92,7 +92,7 @@ namespace NgrokApi
                 ["limit"] = arg.Limit,
             };
             return await apiClient.Do<EventStreamList>(
-                  path: $"/event_streams",
+                  path: $"event_streams",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -129,7 +129,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<EventStream>(
-                  path: $"/event_streams/{arg.Id}",
+                  path: $"event_streams/{arg.Id}",
                   method: new HttpMethod("patch"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/EventSubscriptions.cs
+++ b/NgrokApi/Services/EventSubscriptions.cs
@@ -27,7 +27,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<EventSubscription>(
-                  path: $"/event_subscriptions",
+                  path: $"event_subscriptions",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query
@@ -50,7 +50,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/event_subscriptions/{arg.Id}",
+                  path: $"event_subscriptions/{arg.Id}",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query
@@ -72,7 +72,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<EventSubscription>(
-                  path: $"/event_subscriptions/{arg.Id}",
+                  path: $"event_subscriptions/{arg.Id}",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -91,7 +91,7 @@ namespace NgrokApi
                 ["limit"] = arg.Limit,
             };
             return await apiClient.Do<EventSubscriptionList>(
-                  path: $"/event_subscriptions",
+                  path: $"event_subscriptions",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -128,7 +128,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<EventSubscription>(
-                  path: $"/event_subscriptions/{arg.Id}",
+                  path: $"event_subscriptions/{arg.Id}",
                   method: new HttpMethod("patch"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/IpPolicies.cs
+++ b/NgrokApi/Services/IpPolicies.cs
@@ -36,7 +36,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<IpPolicy>(
-                  path: $"/ip_policies",
+                  path: $"ip_policies",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query
@@ -61,7 +61,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/ip_policies/{arg.Id}",
+                  path: $"ip_policies/{arg.Id}",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query
@@ -83,7 +83,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<IpPolicy>(
-                  path: $"/ip_policies/{arg.Id}",
+                  path: $"ip_policies/{arg.Id}",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -102,7 +102,7 @@ namespace NgrokApi
                 ["limit"] = arg.Limit,
             };
             return await apiClient.Do<IpPolicyList>(
-                  path: $"/ip_policies",
+                  path: $"ip_policies",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -139,7 +139,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<IpPolicy>(
-                  path: $"/ip_policies/{arg.Id}",
+                  path: $"ip_policies/{arg.Id}",
                   method: new HttpMethod("patch"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/IpPolicyRules.cs
+++ b/NgrokApi/Services/IpPolicyRules.cs
@@ -32,7 +32,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<IpPolicyRule>(
-                  path: $"/ip_policy_rules",
+                  path: $"ip_policy_rules",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query
@@ -55,7 +55,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/ip_policy_rules/{arg.Id}",
+                  path: $"ip_policy_rules/{arg.Id}",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query
@@ -77,7 +77,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<IpPolicyRule>(
-                  path: $"/ip_policy_rules/{arg.Id}",
+                  path: $"ip_policy_rules/{arg.Id}",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -96,7 +96,7 @@ namespace NgrokApi
                 ["limit"] = arg.Limit,
             };
             return await apiClient.Do<IpPolicyRuleList>(
-                  path: $"/ip_policy_rules",
+                  path: $"ip_policy_rules",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -133,7 +133,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<IpPolicyRule>(
-                  path: $"/ip_policy_rules/{arg.Id}",
+                  path: $"ip_policy_rules/{arg.Id}",
                   method: new HttpMethod("patch"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/IpRestrictions.cs
+++ b/NgrokApi/Services/IpRestrictions.cs
@@ -36,7 +36,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<IpRestriction>(
-                  path: $"/ip_restrictions",
+                  path: $"ip_restrictions",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query
@@ -59,7 +59,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/ip_restrictions/{arg.Id}",
+                  path: $"ip_restrictions/{arg.Id}",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query
@@ -81,7 +81,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<IpRestriction>(
-                  path: $"/ip_restrictions/{arg.Id}",
+                  path: $"ip_restrictions/{arg.Id}",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -100,7 +100,7 @@ namespace NgrokApi
                 ["limit"] = arg.Limit,
             };
             return await apiClient.Do<IpRestrictionList>(
-                  path: $"/ip_restrictions",
+                  path: $"ip_restrictions",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -137,7 +137,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<IpRestriction>(
-                  path: $"/ip_restrictions/{arg.Id}",
+                  path: $"ip_restrictions/{arg.Id}",
                   method: new HttpMethod("patch"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/ReservedAddrs.cs
+++ b/NgrokApi/Services/ReservedAddrs.cs
@@ -33,7 +33,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<ReservedAddr>(
-                  path: $"/reserved_addrs",
+                  path: $"reserved_addrs",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query
@@ -56,7 +56,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/reserved_addrs/{arg.Id}",
+                  path: $"reserved_addrs/{arg.Id}",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query
@@ -78,7 +78,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<ReservedAddr>(
-                  path: $"/reserved_addrs/{arg.Id}",
+                  path: $"reserved_addrs/{arg.Id}",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -97,7 +97,7 @@ namespace NgrokApi
                 ["limit"] = arg.Limit,
             };
             return await apiClient.Do<ReservedAddrList>(
-                  path: $"/reserved_addrs",
+                  path: $"reserved_addrs",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -134,7 +134,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<ReservedAddr>(
-                  path: $"/reserved_addrs/{arg.Id}",
+                  path: $"reserved_addrs/{arg.Id}",
                   method: new HttpMethod("patch"),
                   body: body,
                   query: query
@@ -157,7 +157,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/reserved_addrs/{arg.Id}/endpoint_configuration",
+                  path: $"reserved_addrs/{arg.Id}/endpoint_configuration",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/ReservedDomains.cs
+++ b/NgrokApi/Services/ReservedDomains.cs
@@ -34,7 +34,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<ReservedDomain>(
-                  path: $"/reserved_domains",
+                  path: $"reserved_domains",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query
@@ -57,7 +57,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/reserved_domains/{arg.Id}",
+                  path: $"reserved_domains/{arg.Id}",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query
@@ -79,7 +79,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<ReservedDomain>(
-                  path: $"/reserved_domains/{arg.Id}",
+                  path: $"reserved_domains/{arg.Id}",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -98,7 +98,7 @@ namespace NgrokApi
                 ["limit"] = arg.Limit,
             };
             return await apiClient.Do<ReservedDomainList>(
-                  path: $"/reserved_domains",
+                  path: $"reserved_domains",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -135,7 +135,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<ReservedDomain>(
-                  path: $"/reserved_domains/{arg.Id}",
+                  path: $"reserved_domains/{arg.Id}",
                   method: new HttpMethod("patch"),
                   body: body,
                   query: query
@@ -158,7 +158,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/reserved_domains/{arg.Id}/certificate_management_policy",
+                  path: $"reserved_domains/{arg.Id}/certificate_management_policy",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query
@@ -180,7 +180,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/reserved_domains/{arg.Id}/certificate",
+                  path: $"reserved_domains/{arg.Id}/certificate",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query
@@ -202,7 +202,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/reserved_domains/{arg.Id}/http_endpoint_configuration",
+                  path: $"reserved_domains/{arg.Id}/http_endpoint_configuration",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query
@@ -224,7 +224,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/reserved_domains/{arg.Id}/https_endpoint_configuration",
+                  path: $"reserved_domains/{arg.Id}/https_endpoint_configuration",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/SshCertificateAuthorities.cs
+++ b/NgrokApi/Services/SshCertificateAuthorities.cs
@@ -32,7 +32,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<SshCertificateAuthority>(
-                  path: $"/ssh_certificate_authorities",
+                  path: $"ssh_certificate_authorities",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query
@@ -55,7 +55,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/ssh_certificate_authorities/{arg.Id}",
+                  path: $"ssh_certificate_authorities/{arg.Id}",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query
@@ -77,7 +77,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<SshCertificateAuthority>(
-                  path: $"/ssh_certificate_authorities/{arg.Id}",
+                  path: $"ssh_certificate_authorities/{arg.Id}",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -96,7 +96,7 @@ namespace NgrokApi
                 ["limit"] = arg.Limit,
             };
             return await apiClient.Do<SshCertificateAuthorityList>(
-                  path: $"/ssh_certificate_authorities",
+                  path: $"ssh_certificate_authorities",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -133,7 +133,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<SshCertificateAuthority>(
-                  path: $"/ssh_certificate_authorities/{arg.Id}",
+                  path: $"ssh_certificate_authorities/{arg.Id}",
                   method: new HttpMethod("patch"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/SshCredentials.cs
+++ b/NgrokApi/Services/SshCredentials.cs
@@ -33,7 +33,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<SshCredential>(
-                  path: $"/ssh_credentials",
+                  path: $"ssh_credentials",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query
@@ -56,7 +56,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/ssh_credentials/{arg.Id}",
+                  path: $"ssh_credentials/{arg.Id}",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query
@@ -78,7 +78,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<SshCredential>(
-                  path: $"/ssh_credentials/{arg.Id}",
+                  path: $"ssh_credentials/{arg.Id}",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -97,7 +97,7 @@ namespace NgrokApi
                 ["limit"] = arg.Limit,
             };
             return await apiClient.Do<SshCredentialList>(
-                  path: $"/ssh_credentials",
+                  path: $"ssh_credentials",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -134,7 +134,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<SshCredential>(
-                  path: $"/ssh_credentials/{arg.Id}",
+                  path: $"ssh_credentials/{arg.Id}",
                   method: new HttpMethod("patch"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/SshHostCertificates.cs
+++ b/NgrokApi/Services/SshHostCertificates.cs
@@ -33,7 +33,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<SshHostCertificate>(
-                  path: $"/ssh_host_certificates",
+                  path: $"ssh_host_certificates",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query
@@ -56,7 +56,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/ssh_host_certificates/{arg.Id}",
+                  path: $"ssh_host_certificates/{arg.Id}",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query
@@ -78,7 +78,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<SshHostCertificate>(
-                  path: $"/ssh_host_certificates/{arg.Id}",
+                  path: $"ssh_host_certificates/{arg.Id}",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -97,7 +97,7 @@ namespace NgrokApi
                 ["limit"] = arg.Limit,
             };
             return await apiClient.Do<SshHostCertificateList>(
-                  path: $"/ssh_host_certificates",
+                  path: $"ssh_host_certificates",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -134,7 +134,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<SshHostCertificate>(
-                  path: $"/ssh_host_certificates/{arg.Id}",
+                  path: $"ssh_host_certificates/{arg.Id}",
                   method: new HttpMethod("patch"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/SshUserCertificates.cs
+++ b/NgrokApi/Services/SshUserCertificates.cs
@@ -33,7 +33,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<SshUserCertificate>(
-                  path: $"/ssh_user_certificates",
+                  path: $"ssh_user_certificates",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query
@@ -56,7 +56,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/ssh_user_certificates/{arg.Id}",
+                  path: $"ssh_user_certificates/{arg.Id}",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query
@@ -78,7 +78,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<SshUserCertificate>(
-                  path: $"/ssh_user_certificates/{arg.Id}",
+                  path: $"ssh_user_certificates/{arg.Id}",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -97,7 +97,7 @@ namespace NgrokApi
                 ["limit"] = arg.Limit,
             };
             return await apiClient.Do<SshUserCertificateList>(
-                  path: $"/ssh_user_certificates",
+                  path: $"ssh_user_certificates",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -134,7 +134,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<SshUserCertificate>(
-                  path: $"/ssh_user_certificates/{arg.Id}",
+                  path: $"ssh_user_certificates/{arg.Id}",
                   method: new HttpMethod("patch"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/TlsCertificates.cs
+++ b/NgrokApi/Services/TlsCertificates.cs
@@ -35,7 +35,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<TlsCertificate>(
-                  path: $"/tls_certificates",
+                  path: $"tls_certificates",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query
@@ -58,7 +58,7 @@ namespace NgrokApi
             {
             };
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/tls_certificates/{arg.Id}",
+                  path: $"tls_certificates/{arg.Id}",
                   method: new HttpMethod("delete"),
                   body: body,
                   query: query
@@ -80,7 +80,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<TlsCertificate>(
-                  path: $"/tls_certificates/{arg.Id}",
+                  path: $"tls_certificates/{arg.Id}",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -99,7 +99,7 @@ namespace NgrokApi
                 ["limit"] = arg.Limit,
             };
             return await apiClient.Do<TlsCertificateList>(
-                  path: $"/tls_certificates",
+                  path: $"tls_certificates",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -136,7 +136,7 @@ namespace NgrokApi
             body = arg;
 
             return await apiClient.Do<TlsCertificate>(
-                  path: $"/tls_certificates/{arg.Id}",
+                  path: $"tls_certificates/{arg.Id}",
                   method: new HttpMethod("patch"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/TunnelSessions.cs
+++ b/NgrokApi/Services/TunnelSessions.cs
@@ -32,7 +32,7 @@ namespace NgrokApi
                 ["limit"] = arg.Limit,
             };
             return await apiClient.Do<TunnelSessionList>(
-                  path: $"/tunnel_sessions",
+                  path: $"tunnel_sessions",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -72,7 +72,7 @@ namespace NgrokApi
             {
             };
             return await apiClient.Do<TunnelSession>(
-                  path: $"/tunnel_sessions/{arg.Id}",
+                  path: $"tunnel_sessions/{arg.Id}",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query
@@ -97,7 +97,7 @@ namespace NgrokApi
             body = arg;
 
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/tunnel_sessions/{arg.Id}/restart",
+                  path: $"tunnel_sessions/{arg.Id}/restart",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query
@@ -119,7 +119,7 @@ namespace NgrokApi
             body = arg;
 
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/tunnel_sessions/{arg.Id}/stop",
+                  path: $"tunnel_sessions/{arg.Id}/stop",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query
@@ -151,7 +151,7 @@ namespace NgrokApi
             body = arg;
 
             await apiClient.DoNoReturnBody<Empty>(
-                  path: $"/tunnel_sessions/{arg.Id}/update",
+                  path: $"tunnel_sessions/{arg.Id}/update",
                   method: new HttpMethod("post"),
                   body: body,
                   query: query

--- a/NgrokApi/Services/Tunnels.cs
+++ b/NgrokApi/Services/Tunnels.cs
@@ -31,7 +31,7 @@ namespace NgrokApi
                 ["limit"] = arg.Limit,
             };
             return await apiClient.Do<TunnelList>(
-                  path: $"/tunnels",
+                  path: $"tunnels",
                   method: new HttpMethod("get"),
                   body: body,
                   query: query


### PR DESCRIPTION
The issue is that when you do the following in the `apiClient.Do` method:

```csharp
new Uri(baseUri, path)
```

This gives the following results:

- `new Uri("http://example.com", "/some-path")` -> `http://example.com/some-path`
- `new Uri("http://example.com", "some-path")` -> `http://example.com/some-path`

That's all good as long as the base URI does not contain a "slash". If it does, it becomes this unexpected result:

- `new Uri("http://example.com/some-sub-path/", "/some-path")` -> `http://example.com/some-path`

Whereas we would have wanted:

- `new Uri("http://example.com/some-sub-path/", "some-path")` -> `http://example.com/some-sub-path/some-path`

The problem is the leading slash that it added to the path. Essentially this makes it impossible to change the API's base URI to `http://localhost:4040/api/` in order to reach the local instance of the Ngrok CLI.

This pull request fixes this, and still leaves the old scenarios running the same.