### PR TITLE
Make error class public

### DIFF
--- a/NgrokApi/Datatypes/Error.cs
+++ b/NgrokApi/Datatypes/Error.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 
 namespace NgrokApi
 {
-    internal class Error
+    public class Error
     {
         [JsonProperty("error_code")]
         public string ErrorCode { get; set; }


### PR DESCRIPTION
There is no reason not to expose it. Users of this library may want to use the models freely.